### PR TITLE
Fix overlay crash when backButton is null (related to issue #29)

### DIFF
--- a/Firefox/Main.js
+++ b/Firefox/Main.js
@@ -403,7 +403,9 @@ function showController() {
   if (!state.controllerElement) return;
 
   state.controllerElement.classList.remove("hidden");
-  state.backButton.style.opacity = "1";
+  if (state.backButton) {
+    state.backButton.style.opacity = "1";
+  }
   state.isControllerVisible = true;
 
   // Show cursor when controls are visible
@@ -423,7 +425,11 @@ function showController() {
         !state.subtitleSettingsOpen
     ) {
       state.controllerElement.classList.add("hidden");
-      state.backButton.style.opacity = "0";
+
+      if (state.backButton) {
+        state.backButton.style.opacity = "0";
+      }
+
       state.isControllerVisible = false;
 
       // Hide cursor when controls are hidden


### PR DESCRIPTION
## Summary

This PR adds a null check for `state.backButton` inside the `showController()` function.  
Without this check, I encountered a `TypeError` (`state.backButton is null`) when the overlay tried to update its opacity, especially when the `backButton` had not yet been initialized.

## Details

- Added conditional checks before accessing `state.backButton.style`
- Prevents overlay logic from crashing on pages where `backButton` is not present or not yet created

## Related

Fixes a problem similar to what's described in [Issue #29](https://github.com/YidirK/Nikflix/issues/29)

## Testing

Tested locally on Firefox using `about:debugging` with temporary extension load.  
Overlay now correctly hides and shows without throwing errors, even when the back button is not yet set.

