### PR TITLE
main.js -> Main.js

### DIFF
--- a/chromium/manifest.json
+++ b/chromium/manifest.json
@@ -27,6 +27,6 @@
     }
   ],
   "background": {
-    "service_worker": "main.js"
+    "service_worker": "Main.js"
   }
 }


### PR DESCRIPTION
When tring to install this extension on linux i was getting an error, when looking into it i found `manifest.json` referenced `main.js` on line 30, i changed this to `Main.js` and it worked. This problem is referenced in issue #46.