### PR TITLE
feat: add autoplay next episode functionality with toggle button

### DIFF
--- a/chromium/netflix-controller.css
+++ b/chromium/netflix-controller.css
@@ -100,6 +100,7 @@
 #netflix-play-pause,
 #netflix-plein-ecran,
 #netflix-next-episode,
+#netflix-autoplay-toggle,
 #netflix-subtitle-toggle,
 #netflix-remove-toggle {
     background-color: transparent;
@@ -118,6 +119,7 @@
 
 #netflix-play-pause:hover,
 #netflix-plein-ecran:hover,
+#netflix-autoplay-toggle:hover,
 #netflix-subtitle-toggle:hover,
 #netflix-remove-toggle:hover {
     background-color: rgba(255, 255, 255, 0.1);
@@ -126,6 +128,7 @@
 
 #netflix-play-pause:active,
 #netflix-plein-ecran:active,
+#netflix-autoplay-toggle:active,
 #netflix-subtitle-toggle:active,
 #netflix-remove-toggle:active {
     transform: scale(0.95);


### PR DESCRIPTION
## 🎬 Feature: Add autoplay next episode option

### 🎯 Problem
Currently, when an episode finishes, Netflix pauses playback and stops. Users must manually click to start the next episode, interrupting their viewing experience. This is especially inconvenient for binge-watching sessions where viewers want continuous playback through multiple episodes.

### ✨ Solution
Implemented an **autoplay toggle button** in the controller that automatically jumps to the next episode when the current one ends:

1. **Toggle button**: New button in the controls (next to the "next episode" button) to enable/disable autoplay.
2. **Auto-advance**: When enabled and an episode ends, automatically jumps to the next episode after a 1.5-second delay.
3. **User feedback**: Displays "Playing next episode..." message before jumping.
4. **Persistent preference**: The autoplay setting is saved to `chrome.storage.local` and remembered across sessions.
5. **Graceful fallback**: If `jumpToNextEpisode()` fails or there's no next episode, the player stays on the end screen.

### 🔧 Technical Changes

- **New toggle button**: `#netflix-autoplay-toggle` in the controls UI.
- **Event listener**: Added `ended` event listener to the video element that triggers autoplay logic.
- **Storage integration**: Load/save autoplay preference from `chrome.storage.local` on controller init.
- **State property**: `state.autoplayNextEpisode` tracks the current autoplay state.
- **CSS styling**: Button matches other control buttons with transparent background, white hover effect, and proper transitions.

### ✅ Benefits

- ✅ Seamless episode transitions without manual intervention.
- ✅ Better binge-watching experience (Netflix-like behavior).
- ✅ User has full control (toggle on/off anytime).
- ✅ Preference persists across browser sessions.
- ✅ Non-intrusive (only activates when explicitly enabled).

### 📝 Notes
- Requires the `jumpToNextEpisode()` function to exist (already present in the codebase).
- The 1.5-second delay before jumping mimics Netflix's standard UX pattern.
- Falls back gracefully if no next episode is available.
- This implementation is for Chromium. The same changes can be applied to Firefox with minimal modifications.