### PR TITLE
fix: hide restriction screens via CSS and prevent video pause

### DIFF
--- a/Firefox/netflix-controller.css
+++ b/Firefox/netflix-controller.css
@@ -1,3 +1,10 @@
+.nf-modal.interstitial-full-screen,
+.nf-modal.uma-modal.two-section-uma,
+.nf-modal.extended-diacritics-language.interstitial-full-screen,
+.css-1nym653.modal-enter-done {
+    display: none !important;
+}
+
 #mon-controleur-netflix {
     position: fixed;
     bottom: 0;

--- a/chromium/Main.js
+++ b/chromium/Main.js
@@ -1,3 +1,15 @@
+// Early CSS to hide restriction screens before they even render
+const earlyStyle = document.createElement("style");
+earlyStyle.textContent = `
+  .nf-modal.interstitial-full-screen,
+  .nf-modal.uma-modal.two-section-uma,
+  .nf-modal.extended-diacritics-language.interstitial-full-screen,
+  .css-1nym653.modal-enter-done {
+    display: none !important;
+  }
+`;
+(document.head || document.documentElement).appendChild(earlyStyle);
+
 const CLASSES_TO_REMOVE = [
   "layout-item_styles__zc08zp30 default-ltr-cache-7vbe6a ermvlvv0",
   "default-ltr-cache-1sfbp89 e1qcljkj0",
@@ -1434,6 +1446,25 @@ const observerOptions = {
 
 const observer = new MutationObserver((mutations) => {
   if (state.mutationTimeout) clearTimeout(state.mutationTimeout);
+
+  // Handle restriction screen: remove it, resume video and show controller
+  const hasRestrictionNode = mutations.some((mutation) =>
+    Array.from(mutation.addedNodes).some((node) => {
+      if (node.nodeType !== Node.ELEMENT_NODE) return false;
+      const cls = node.className || "";
+      return typeof cls === "string" && CLASSES_TO_REMOVE.some((c) => cls.includes(c));
+    })
+  );
+  if (hasRestrictionNode) {
+    removeElementsByClasses(CLASSES_TO_REMOVE);
+    const video = document.querySelector("video");
+    if (video) {
+      video.play();
+      if (state.controllerTimerId) clearTimeout(state.controllerTimerId);
+      state.controllerTimerId = null;
+      addMediaController();
+    }
+  }
 
   state.mutationTimeout = setTimeout(() => {
     const hasRelevantChanges = mutations.some((mutation) => {

--- a/chromium/netflix-controller.css
+++ b/chromium/netflix-controller.css
@@ -1,3 +1,10 @@
+.nf-modal.interstitial-full-screen,
+.nf-modal.uma-modal.two-section-uma,
+.nf-modal.extended-diacritics-language.interstitial-full-screen,
+.css-1nym653.modal-enter-done {
+    display: none !important;
+}
+
 #mon-controleur-netflix {
     position: fixed;
     bottom: 0;


### PR DESCRIPTION
noticed a flickering restriction screen popping up every time i opened a title, then getting removed by the extension
used css to hide it before it even renders, and also made sure the video resumes and the controller shows up right away