### PR TITLE
fix: clicks not working in homepage 

### DIFF
--- a/Firefox/Main.js
+++ b/Firefox/Main.js
@@ -821,6 +821,9 @@ function createVideoOverlay() {
 }
 
 function createVideoAreaOverlay() {
+  const curEpisodeId = getIdFromUrl();
+  if (!curEpisodeId) return null; // If we can't get the episode ID, we won't create the overlay
+
   const videoAreaOverlay = document.createElement("div");
   videoAreaOverlay.id = "netflix-video-area-overlay";
   videoAreaOverlay.style.position = "fixed";

--- a/chromium/Main.js
+++ b/chromium/Main.js
@@ -851,6 +851,9 @@ function createVideoOverlay() {
 }
 
 function createVideoAreaOverlay() {
+  const curEpisodeId = getIdFromUrl();
+  if (!curEpisodeId) return null; // If we can't get the episode ID, we won't create the overlay
+
   const videoAreaOverlay = document.createElement("div");
   videoAreaOverlay.id = "netflix-video-area-overlay";
   videoAreaOverlay.style.position = "fixed";


### PR DESCRIPTION
addresses #54 #57 #70 #74 #80 #86 

currently, we create the `netflix-video-area-overlay` on every page with a video, including the homepage where trailers/previews autoplay

this overlay is covering the entire homepage video area, blocking all clicks underneath it, making the homepage completely unusable when the trailer appears...

so I added an episode ID check before creating video area overlay, this way, the overlay is only created when actually watching something