### PR TITLE
Add selectable native Netflix controller mode

### DIFF
--- a/chromium/Main.js
+++ b/chromium/Main.js
@@ -1473,6 +1473,8 @@ function addMediaController() {
       controller.style.display = "none";
       if (overlayArea) overlayArea.style.display = "none";
       if (overlay) overlay.style.display = "none";
+      if (state.backButton) state.backButton.style.display = "none";
+      if (state.tipsButton) state.tipsButton.style.display = "none";
     }
   });
 }
@@ -1919,14 +1921,18 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
   const overlay = document.getElementById("netflix-video-overlay");
 
   if (message.message === "enable") {
-    controller.style.display = "flex";
-    overlayArea.style.display = "flex";
-    overlay.style.display = "flex";
+    if (controller) controller.style.display = "flex";
+    if (overlayArea) overlayArea.style.display = "flex";
+    if (overlay) overlay.style.display = "flex";
+    if (state.backButton) state.backButton.style.display = "flex";
+    if (state.tipsButton) state.tipsButton.style.display = "flex";
     showMessage("Controller Enabled");
   } else if (message.message === "disable") {
-    controller.style.display = "none";
-    overlayArea.style.display = "none";
-    overlay.style.display = "none";
+    if (controller) controller.style.display = "none";
+    if (overlayArea) overlayArea.style.display = "none";
+    if (overlay) overlay.style.display = "none";
+    if (state.backButton) state.backButton.style.display = "none";
+    if (state.tipsButton) state.tipsButton.style.display = "none";
     showMessage("Controller Disabled");
     console.log("Disabled");
   } else if (message.message === "debug") {

--- a/chromium/manifest.json
+++ b/chromium/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Nikflix (Household Bypass)",
   "description": "Bypass the account-sharing restrictions on Netflix.",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "manifest_version": 3,
   "default_locale": "en",
   "action": {
@@ -22,6 +22,21 @@
     }
   ],
   "content_scripts": [
+    {
+      "js": ["native-mode-bridge.js"],
+      "matches": [
+        "*://*.netflix.com/*"
+      ],
+      "run_at": "document_start"
+    },
+    {
+      "js": ["native-mode-page.js"],
+      "matches": [
+        "*://*.netflix.com/*"
+      ],
+      "run_at": "document_start",
+      "world": "MAIN"
+    },
     {
       "js": ["Main.js"],
       "css": ["netflix-controller.css"],

--- a/chromium/native-mode-bridge.js
+++ b/chromium/native-mode-bridge.js
@@ -1,0 +1,45 @@
+(() => {
+  "use strict";
+
+  const CONFIG_MESSAGE_TYPE = "NIKFLIX_NATIVE_MODE_CONFIG_V1";
+  const CONFIG_READY_MESSAGE_TYPE = "NIKFLIX_NATIVE_MODE_READY_V1";
+  let currentNativeMode = false;
+
+  function publishNativeMode(nativeModeEnabled) {
+    currentNativeMode = nativeModeEnabled;
+    postMessage(
+      {
+        type: CONFIG_MESSAGE_TYPE,
+        nativeModeEnabled,
+      },
+      "*"
+    );
+  }
+
+  // Remove temporary diagnostic data left by development builds.
+  chrome.storage.local.remove([
+    "nikflixDiagnosticTimelineV1",
+    "nikflixNetworkDiagnosticTimelineV1",
+  ]);
+
+  chrome.storage.local.get(["status"], (result) => {
+    publishNativeMode(result.status === "disable");
+  });
+
+  addEventListener("message", (event) => {
+    if (
+      event.source === window &&
+      event.data?.type === CONFIG_READY_MESSAGE_TYPE
+    ) {
+      publishNativeMode(currentNativeMode);
+    }
+  });
+
+  chrome.runtime.onMessage.addListener((message) => {
+    if (message?.message === "disable") {
+      publishNativeMode(true);
+    } else if (message?.message === "enable") {
+      publishNativeMode(false);
+    }
+  });
+})();

--- a/chromium/native-mode-page.js
+++ b/chromium/native-mode-page.js
@@ -1,0 +1,112 @@
+(() => {
+  "use strict";
+
+  const CONFIG_MESSAGE_TYPE = "NIKFLIX_NATIVE_MODE_CONFIG_V1";
+  const CONFIG_READY_MESSAGE_TYPE = "NIKFLIX_NATIVE_MODE_READY_V1";
+  const RESTRICTION_OPERATION = "CLCSInterstitialPlaybackAndPostPlayback";
+  const RESTRICTION_HOST = "web.prod.cloud.netflix.com";
+  const RESTRICTION_PATH = "/graphql";
+
+  let nativeModeEnabled = false;
+  const heldRequests = [];
+  const originalFetch = window.fetch;
+
+  function isRestrictionEndpoint(rawUrl) {
+    try {
+      const url = new URL(rawUrl, location.href);
+      return (
+        url.hostname === RESTRICTION_HOST &&
+        url.pathname === RESTRICTION_PATH
+      );
+    } catch (_error) {
+      return false;
+    }
+  }
+
+  function getOperationNames(body) {
+    if (typeof body !== "string") return [];
+
+    try {
+      const parsed = JSON.parse(body);
+      const operations = Array.isArray(parsed) ? parsed : [parsed];
+
+      return operations
+        .map((operation) => operation?.operationName)
+        .filter((name) => typeof name === "string");
+    } catch (_error) {
+      return [];
+    }
+  }
+
+  function shouldHold(rawUrl, body) {
+    return (
+      nativeModeEnabled &&
+      isRestrictionEndpoint(rawUrl) &&
+      getOperationNames(body).includes(RESTRICTION_OPERATION)
+    );
+  }
+
+  function holdRequest(thisArg, args) {
+    return new Promise((resolve, reject) => {
+      heldRequests.push({ thisArg, args, resolve, reject });
+    });
+  }
+
+  function releaseHeldRequests() {
+    const requests = heldRequests.splice(0);
+
+    for (const request of requests) {
+      originalFetch
+        .apply(request.thisArg, request.args)
+        .then(request.resolve, request.reject);
+    }
+  }
+
+  window.fetch = function (input, init) {
+    const thisArg = this;
+    const args = arguments;
+    const rawUrl =
+      typeof input === "string" || input instanceof URL
+        ? String(input)
+        : input?.url;
+
+    try {
+      if (init?.body !== undefined) {
+        return shouldHold(rawUrl, init.body)
+          ? holdRequest(thisArg, args)
+          : originalFetch.apply(thisArg, args);
+      }
+
+      if (input instanceof Request && isRestrictionEndpoint(rawUrl)) {
+        return input
+          .clone()
+          .text()
+          .catch(() => "")
+          .then((body) =>
+            shouldHold(rawUrl, body)
+              ? holdRequest(thisArg, args)
+              : originalFetch.apply(thisArg, args)
+          );
+      }
+    } catch (_error) {
+      // Native mode must never interfere with unrelated Netflix requests.
+    }
+
+    return originalFetch.apply(thisArg, args);
+  };
+
+  addEventListener("message", (event) => {
+    if (
+      event.source !== window ||
+      event.data?.type !== CONFIG_MESSAGE_TYPE ||
+      typeof event.data.nativeModeEnabled !== "boolean"
+    ) {
+      return;
+    }
+
+    nativeModeEnabled = event.data.nativeModeEnabled;
+    if (!nativeModeEnabled) releaseHeldRequests();
+  });
+
+  postMessage({ type: CONFIG_READY_MESSAGE_TYPE }, "*");
+})();

--- a/chromium/popup.html
+++ b/chromium/popup.html
@@ -485,14 +485,14 @@ __  __    __    ____  ____    ____  _  _    _   _  __  __  __  __    __    _  _ 
     </div>
 </div>
 
-<!-- Controller toggle -->
+<!-- Player mode toggle -->
 <div class="controller-toggle" style="margin-bottom: 4px;">
-    <span class="toggle-label" data-i18n="controllerLabel">Controller</span>
+    <span class="toggle-label">Player mode</span>
     <label class="toggle-switch">
         <input type="checkbox" id="controllerToggle" checked>
         <span class="slider"></span>
     </label>
-    <span class="status-text" id="statusText" data-i18n="statusEnabled">Enable</span>
+    <span class="status-text" id="statusText">Nikflix (Stable)</span>
 </div>
 
 <!-- Footer -->

--- a/chromium/popup.js
+++ b/chromium/popup.js
@@ -100,7 +100,9 @@ toggle.addEventListener('change', function() {
 
 
     const message = this.checked ? "enable" : "disable";
-    statusText.textContent = this.checked ? "Enable" : "Disable";
+    statusText.textContent = this.checked
+        ? "Nikflix (Stable)"
+        : "Netflix (Experimental)";
     statusText.className = this.checked ? "status-text status-active" : "status-text status-inactive";
 
 
@@ -125,7 +127,9 @@ document.addEventListener('DOMContentLoaded', function() {
         const status = result.status || "enable";
 
         toggle.checked = (status === "enable");
-        statusText.textContent = toggle.checked ? 'Enable' : 'Disable';
+        statusText.textContent = toggle.checked
+            ? 'Nikflix (Stable)'
+            : 'Netflix (Experimental)';
         statusText.className = toggle.checked ? 'status-text status-active' : 'status-text status-inactive';
     });
 });


### PR DESCRIPTION
## Summary

- add a selectable **Netflix (Experimental)** mode that keeps Netflix's native React player controls
- retain **Nikflix (Stable)** as the default/current custom-controller bypass and immediate fallback
- synchronize the selected mode between the extension's isolated content-script context and Netflix's main page context at `document_start`
- hide Nikflix-specific overlays and corner actions while native mode is selected
- update the Chromium extension version to `1.9.4`

## Root cause

When Netflix decides to show the household interstitial, it pauses playback and unmounts its native controller before inserting the restriction modal. Removing the modal and resuming the `<video>` therefore cannot restore controls such as Skip Intro, Skip Recap, the native timeline, audio/subtitle menus, or the next-episode UI.

During live debugging, the controller teardown consistently occurred immediately after the `CLCSInterstitialPlaybackAndPostPlayback` GraphQL operation completed.

## Implementation

The experimental mode installs a narrowly scoped main-world `fetch` guard before Netflix's application scripts run. It examines only the GraphQL `operationName` and holds requests when all of these conditions match:

1. the user selected **Netflix (Experimental)**;
2. the host is `web.prod.cloud.netflix.com`;
3. the path is `/graphql`;
4. the operation is exactly `CLCSInterstitialPlaybackAndPostPlayback`.

No unrelated request is modified. Request headers, cookies, tokens, variables, responses, and account data are not persisted or exported.

Switching to **Nikflix (Stable)** releases any held request and restores the existing custom-controller behavior, providing an explicit fallback if Netflix changes the endpoint or operation.

## User impact

In experimental mode, Netflix remains in its normal player state, so the original controller and its React-managed features continue working. Users can switch back to the established Nikflix controller from the popup at any time.

## Validation

- live-tested across multiple next-episode transitions with the native controller remaining functional
- confirmed that the household modal was not mounted while the targeted operation was held
- confirmed that the native controls remained React-managed rather than being detached/reinserted DOM
- confirmed the stable fallback remains selectable and releases held requests
- ran `node --check` on all changed JavaScript files
- parsed `chromium/manifest.json` successfully
- ran `git diff --check`

## Scope and risks

- Chromium only; Firefox is unchanged
- the experimental path depends on an undocumented Netflix endpoint and operation name and may require maintenance if Netflix changes its implementation
- the stable mode remains the default fallback
- this PR intentionally contains no diagnostic recorder or network/DOM export tooling used during investigation
