### PR TITLE
fix: popup not loading due to i18n import casing

### DIFF
--- a/chromium/popup.js
+++ b/chromium/popup.js
@@ -1,5 +1,5 @@
 
-import { t, applyI18n } from './i18n.js';
+import { t, applyI18n } from './I18n.js';
 
 
 


### PR DESCRIPTION
popup.js imports './i18n.js' but the file is 'I18n.js', so on linux the import 404s and since it's a module the whole thing never runs

not from #92, reproduces on 1.9.3 and still on master after the revert (probably what #111 and #117 are hitting too)