### PR TITLE
fix: clashing player uis on accounts without the restriction

### DIFF
--- a/Firefox/Main.js
+++ b/Firefox/Main.js
@@ -342,6 +342,8 @@ function createStylesIfNeeded() {
  * Clean up controller elements and reset state
  */
 function cleanController() {
+  document.body.classList.remove("nikflix-active");
+
   if (state.progressionIntervalId) {
     cancelAnimationFrame(state.progressionIntervalId);
     state.progressionIntervalId = null;
@@ -1508,6 +1510,7 @@ function addMediaController() {
   document.body.appendChild(state.videoOverlay);
   document.body.appendChild(state.controllerElement);
   state.isControllerAdded = true;
+  document.body.classList.add("nikflix-active");
 
   updateProgression();
 
@@ -2011,11 +2014,14 @@ browser.runtime.onMessage.addListener((message, sender) => {
     controller.style.display = "flex";
     overlayArea.style.display = "flex";
     overlay.style.display = "flex";
+    document.body.classList.add("nikflix-active");
     showMessage("Controller Enabled");
   } else if (message.message === "disable") {
     controller.style.display = "none";
     overlayArea.style.display = "none";
     overlay.style.display = "none";
+    // give netflix's own controls back, otherwise there are none at all
+    document.body.classList.remove("nikflix-active");
     showMessage("Controller Disabled");
     console.log("Disabled");
   } else if (message.message === "debug") {

--- a/Firefox/manifest.json
+++ b/Firefox/manifest.json
@@ -20,6 +20,9 @@
       ],
       "js": [
         "Main.js"
+      ],
+      "css": [
+        "netflix-controller.css"
       ]
     }
   ]

--- a/Firefox/netflix-controller.css
+++ b/Firefox/netflix-controller.css
@@ -753,3 +753,12 @@ input:checked + .subtitle-toggle-slider:before {
     opacity: 1;
     transform: translateX(-50%) translateY(-2px);
 }
+/* Netflix's own player UI, hidden while our controller is on screen.
+   Netflix only unmounts these itself when the household interstitial fires,
+   so accounts without the restriction were seeing both UIs at once. */
+body.nikflix-active [data-uia="controls-standard"],
+body.nikflix-active .watch-video--bottom-controls-container,
+body.nikflix-active .watch-video--back-container,
+body.nikflix-active .watch-video--flag-container {
+  display: none !important;
+}

--- a/chromium/Main.js
+++ b/chromium/Main.js
@@ -343,6 +343,8 @@ function createStylesIfNeeded() {
  * Clean up controller elements and reset state
  */
 function cleanController() {
+  document.body.classList.remove("nikflix-active");
+
   if (state.progressionIntervalId) {
     cancelAnimationFrame(state.progressionIntervalId);
     state.progressionIntervalId = null;
@@ -1509,6 +1511,7 @@ function addMediaController() {
   document.body.appendChild(state.videoOverlay);
   document.body.appendChild(state.controllerElement);
   state.isControllerAdded = true;
+  document.body.classList.add("nikflix-active");
 
   updateProgression();
 
@@ -2012,11 +2015,14 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
     controller.style.display = "flex";
     overlayArea.style.display = "flex";
     overlay.style.display = "flex";
+    document.body.classList.add("nikflix-active");
     showMessage("Controller Enabled");
   } else if (message.message === "disable") {
     controller.style.display = "none";
     overlayArea.style.display = "none";
     overlay.style.display = "none";
+    // give netflix's own controls back, otherwise there are none at all
+    document.body.classList.remove("nikflix-active");
     showMessage("Controller Disabled");
     console.log("Disabled");
   } else if (message.message === "debug") {

--- a/chromium/netflix-controller.css
+++ b/chromium/netflix-controller.css
@@ -756,4 +756,13 @@ input:checked + .subtitle-toggle-slider:before {
     opacity: 1;
     transform: translateX(-50%) translateY(-2px);
   }
-  
+
+/* Netflix's own player UI, hidden while our controller is on screen.
+   Netflix only unmounts these itself when the household interstitial fires,
+   so accounts without the restriction were seeing both UIs at once. */
+body.nikflix-active [data-uia="controls-standard"],
+body.nikflix-active .watch-video--bottom-controls-container,
+body.nikflix-active .watch-video--back-container,
+body.nikflix-active .watch-video--flag-container {
+  display: none !important;
+}


### PR DESCRIPTION
nikflix relies on netflix unmounting its own controls when the household interstitial fires, so accounts without the restriction get both uis at once

adds a nikflix-active class on body while our controller is up and hides netflix's controls with css, disabling from the popup removes it so their controls come back

addresses #100