### PR TITLE
fix: controller delay and null video typeerror

### DIFF
--- a/Firefox/Main.js
+++ b/Firefox/Main.js
@@ -1598,15 +1598,34 @@ function doYourJob() {
     // Use debounce technique to prevent multiple calls
     if (state.controllerTimerId) {
       clearTimeout(state.controllerTimerId);
+      state.controllerTimerId = null;
     }
 
-    state.controllerTimerId = setTimeout(() => {
-      addMediaController();
+    const startController = () => {
       state.controllerTimerId = null;
+      addMediaController();
+
+      // no <video> yet, so nothing was built. a later mutation will retry
+      if (!state.isControllerAdded) return;
+
       state.videoElement.play();
       state.buttonPlayPause.innerHTML =
           '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M14 19H18V5H14V19ZM6 19H10V5H6V19Z" fill="white"/></svg>';
-    }, CONTROLLER_INIT_DELAY);
+    };
+
+    // Netflix shows its own controls the moment the player is ready, so build
+    // ours as soon as the video has metadata instead of waiting out a fixed
+    // delay that ran long after everything was already in place.
+    const video = document.querySelector("video");
+    if (video && video.readyState >= 1) {
+      startController();
+    } else {
+      if (video) {
+        video.addEventListener("loadedmetadata", startController, { once: true });
+      }
+      // fallback for a video that never reports metadata
+      state.controllerTimerId = setTimeout(startController, CONTROLLER_INIT_DELAY);
+    }
   } else {
     removeElementsByClasses(CLASSES_TO_REMOVE);
     cleanController();

--- a/Firefox/Main.js
+++ b/Firefox/Main.js
@@ -1603,10 +1603,11 @@ function doYourJob() {
 
     const startController = () => {
       state.controllerTimerId = null;
+      const alreadyBuilt = state.isControllerAdded;
       addMediaController();
 
-      // no <video> yet, so nothing was built. a later mutation will retry
-      if (!state.isControllerAdded) return;
+      // only resume on the first build, never fight a deliberate pause
+      if (alreadyBuilt || !state.isControllerAdded) return;
 
       state.videoElement.play();
       state.buttonPlayPause.innerHTML =

--- a/chromium/Main.js
+++ b/chromium/Main.js
@@ -1599,15 +1599,34 @@ function doYourJob() {
     // Use debounce technique to prevent multiple calls
     if (state.controllerTimerId) {
       clearTimeout(state.controllerTimerId);
+      state.controllerTimerId = null;
     }
 
-    state.controllerTimerId = setTimeout(() => {
-      addMediaController();
+    const startController = () => {
       state.controllerTimerId = null;
+      addMediaController();
+
+      // no <video> yet, so nothing was built. a later mutation will retry
+      if (!state.isControllerAdded) return;
+
       state.videoElement.play();
       state.buttonPlayPause.innerHTML =
           '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M14 19H18V5H14V19ZM6 19H10V5H6V19Z" fill="white"/></svg>';
-    }, CONTROLLER_INIT_DELAY);
+    };
+
+    // Netflix shows its own controls the moment the player is ready, so build
+    // ours as soon as the video has metadata instead of waiting out a fixed
+    // delay that ran long after everything was already in place.
+    const video = document.querySelector("video");
+    if (video && video.readyState >= 1) {
+      startController();
+    } else {
+      if (video) {
+        video.addEventListener("loadedmetadata", startController, { once: true });
+      }
+      // fallback for a video that never reports metadata
+      state.controllerTimerId = setTimeout(startController, CONTROLLER_INIT_DELAY);
+    }
   } else {
     removeElementsByClasses(CLASSES_TO_REMOVE);
     cleanController();

--- a/chromium/Main.js
+++ b/chromium/Main.js
@@ -1604,10 +1604,11 @@ function doYourJob() {
 
     const startController = () => {
       state.controllerTimerId = null;
+      const alreadyBuilt = state.isControllerAdded;
       addMediaController();
 
-      // no <video> yet, so nothing was built. a later mutation will retry
-      if (!state.isControllerAdded) return;
+      // only resume on the first build, never fight a deliberate pause
+      if (alreadyBuilt || !state.isControllerAdded) return;
 
       state.videoElement.play();
       state.buttonPlayPause.innerHTML =


### PR DESCRIPTION
always noticed some weird delay of a few seconds for our controller to appear, so today, i decided to fix it

`doYourJob()` wrapped `addMediaController()` in a blind 1500ms `setTimeout` so it fired even when the player was already ready, and when netflix's video wasn't in the dom yet `addMediaController()` bailed leaving `state.videoElement` null, then the timer called `state.videoElement.play()` on it, a typeerror on every load with each failed cycle costing another 1500ms

now it builds when the video reports metadata (`readyState >= 1` or the `loadedmetadata` event), old timer kept only as a fallback for a video that never reports it

went from ~1.5s after the player was ready down to a few ms, and the typeerror is gone

also fixes a paused video resuming on its own, that `play()` ran on every `doYourJob()` pass and toggling subtitles calls `doYourJob()` so it fought a deliberate pause, now it only resumes on the first build