### PR TITLE
fix: click dead zone and small ui tweaks

### DIFF
--- a/Firefox/Main.js
+++ b/Firefox/Main.js
@@ -454,6 +454,19 @@ function showController() {
   }
   state.isControllerVisible = true;
 
+  // netflix lifts its skip buttons by reflow, ours is fixed so it can't
+  document.body.classList.add("nikflix-controls-visible");
+  if (state.controllerElement) {
+    // the top padding is just transparent gradient, only clear the controls
+    const rect = state.controllerElement.getBoundingClientRect();
+    const padTop =
+      parseFloat(getComputedStyle(state.controllerElement).paddingTop) || 0;
+    document.body.style.setProperty(
+      "--nikflix-controls-height",
+      `${Math.round(rect.height - padTop)}px`
+    );
+  }
+
   // Show cursor when controls are visible
   const videoAreaOverlay = document.getElementById(
       "netflix-video-area-overlay"
@@ -482,10 +495,12 @@ function showController() {
       }
 
       state.isControllerVisible = false;
+      document.body.classList.remove("nikflix-controls-visible");
 
       // Hide cursor when controls are hidden
       if (videoAreaOverlay) {
         videoAreaOverlay.style.cursor = "none";
+        videoAreaOverlay.classList.remove("over-netflix-button");
       }
     }
   }, CONTROLLER_HIDE_DELAY);
@@ -879,6 +894,66 @@ function createVideoOverlay() {
   document.body.appendChild(state.videoOverlay);
 }
 
+const NETFLIX_PASSTHROUGH_BUTTONS =
+  '[data-uia^="player-skip"], [data-uia$="seamless-button"], [data-uia$="seamless-button-draining"]';
+
+// netflix never dismisses its next episode controls on a seek, so key them off
+// how far the playhead is from the end instead
+const SEAMLESS_END_WINDOW_S = 120;
+
+function updateSeamlessDistance() {
+  const video = state.videoElement;
+  if (!video || !video.duration || Number.isNaN(video.duration)) return;
+
+  const remaining = video.duration - video.currentTime;
+  document.body.classList.toggle(
+    "nikflix-away-from-end",
+    remaining > SEAMLESS_END_WINDOW_S
+  );
+}
+
+function cancelNetflixCountdown() {
+  const container = document.querySelector(".SeamlessControls--container");
+  if (!container) return;
+
+  // netflix only cancels its next episode countdown once the mouse has
+  // travelled ~50px over this container, and our overlay swallows the real
+  // events, so replay enough of them to clear its timers
+  for (let i = 0; i < 8; i++) {
+    container.dispatchEvent(
+      new MouseEvent("mousemove", {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        clientX: 200 + i * 20,
+        clientY: 300,
+      })
+    );
+  }
+}
+
+function forwardHover(from, to) {
+  const fire = (el, types, related) => {
+    for (const type of types) {
+      const Ctor = type.startsWith("pointer") ? PointerEvent : MouseEvent;
+      el.dispatchEvent(
+        new Ctor(type, {
+          bubbles: type.endsWith("over") || type.endsWith("out"),
+          cancelable: true,
+          composed: true,
+          relatedTarget: related || null,
+          ...(Ctor === PointerEvent
+            ? { pointerId: 1, pointerType: "mouse", isPrimary: true }
+            : {}),
+        })
+      );
+    }
+  };
+
+  if (from) fire(from, ["pointerout", "mouseout", "pointerleave", "mouseleave"], to);
+  if (to) fire(to, ["pointerover", "mouseover", "pointerenter", "mouseenter"], from);
+}
+
 function createVideoAreaOverlay() {
   const curEpisodeId = getIdFromUrl();
   if (!curEpisodeId) return null; // If we can't get the episode ID, we won't create the overlay
@@ -922,6 +997,13 @@ function createVideoAreaOverlay() {
       return;
     }
 
+    const passthroughButton =
+      elementBelow && elementBelow.closest(NETFLIX_PASSTHROUGH_BUTTONS);
+    if (passthroughButton) {
+      passthroughButton.click();
+      return;
+    }
+
     if (state.videoElement.paused) {
       state.videoElement.play();
       if (state.buttonPlayPause) {
@@ -934,6 +1016,45 @@ function createVideoAreaOverlay() {
         state.buttonPlayPause.innerHTML =
             '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8 5V19L19 12L8 5Z" fill="white"/></svg>';
       }
+    }
+  });
+
+  // netflix's skip buttons sit under our overlay, so show a pointer over them
+  let lastCursorCheck = 0;
+  let lastHovered = null;
+  videoAreaOverlay.addEventListener("mousemove", (e) => {
+    // the hit test forces a style recalc, so keep it off every mousemove
+    if (e.timeStamp - lastCursorCheck < 100) return;
+    lastCursorCheck = e.timeStamp;
+
+    videoAreaOverlay.style.pointerEvents = "none";
+    const below = document.elementFromPoint(e.clientX, e.clientY);
+    videoAreaOverlay.style.pointerEvents = "auto";
+    const hovered = below && below.closest(NETFLIX_PASSTHROUGH_BUTTONS);
+
+    // a class, not an inline style: the show-controls handler also writes
+    // cursor on mousemove and would overwrite us
+    videoAreaOverlay.classList.toggle("over-netflix-button", !!hovered);
+
+    // only while actually over a button: the seamless container is full-bleed,
+    // and feeding it activity everywhere kept netflix's controls awake forever
+    if (hovered) {
+      below.dispatchEvent(
+        new MouseEvent("mousemove", {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          clientX: e.clientX,
+          clientY: e.clientY,
+        })
+      );
+    }
+
+    if (hovered !== lastHovered) {
+      // netflix pauses its autoplay countdown on hover, but the overlay
+      // swallows the real events so they have to be replayed
+      forwardHover(lastHovered, hovered);
+      lastHovered = hovered;
     }
   });
 
@@ -1367,6 +1488,10 @@ function addMediaController() {
       state.isControllerVisible = true;
     }
   });
+
+  // seeking away means the user is not waiting for the next episode
+  state.videoElement.addEventListener("seeked", cancelNetflixCountdown);
+  state.videoElement.addEventListener("timeupdate", updateSeamlessDistance);
 
   // Listen for video end event for autoplay next episode
   state.videoElement.addEventListener("ended", () => {

--- a/Firefox/Main.js
+++ b/Firefox/Main.js
@@ -1314,9 +1314,6 @@ function addMediaController() {
     }
   });
 
-  // Append to right controls bar
-  controlsRight.appendChild(speedToggleButton);
-
   // === Autoplay Next Episode Toggle ===
   const autoplayToggleButton = document.createElement("button");
   autoplayToggleButton.id = "netflix-autoplay-toggle";
@@ -1488,8 +1485,8 @@ function addMediaController() {
   controlsRight.appendChild(episodesButton);
   controlsRight.appendChild(removeToggle);
   controlsRight.appendChild(subtitleToggle);
-  controlsRight.appendChild(state.buttonFullScreen);
   controlsRight.appendChild(speedToggleButton);
+  controlsRight.appendChild(state.buttonFullScreen);
 
   state.controllerElement.appendChild(controlsLeft);
   state.controllerElement.appendChild(progressContainer);

--- a/Firefox/Main.js
+++ b/Firefox/Main.js
@@ -459,7 +459,7 @@ function showController() {
       "netflix-video-area-overlay"
   );
   if (videoAreaOverlay) {
-    videoAreaOverlay.style.cursor = "pointer";
+    videoAreaOverlay.style.cursor = "default";
   }
 
   if (state.controllerHideTimer) {
@@ -889,9 +889,9 @@ function createVideoAreaOverlay() {
   videoAreaOverlay.style.top = "0";
   videoAreaOverlay.style.left = "0";
   videoAreaOverlay.style.width = "100%";
-  videoAreaOverlay.style.height = "calc(100% - 140px)";
+  videoAreaOverlay.style.height = "100%";
   videoAreaOverlay.style.zIndex = "9997";
-  videoAreaOverlay.style.cursor = "pointer";
+  videoAreaOverlay.style.cursor = "default";
   videoAreaOverlay.style.backgroundColor = "transparent";
 
   // Make it focusable
@@ -1086,17 +1086,6 @@ function addMediaController() {
   state.videoOverlay = document.createElement("div");
   state.videoOverlay.id = "netflix-video-overlay";
   state.videoOverlay.style.pointerEvents = "none"; // Allow clicks to pass through to Netflix's controls
-
-  // Create a separate overlay just for the video area (excluding controls)
-  videoAreaOverlay.id = "netflix-video-area-overlay";
-  videoAreaOverlay.style.position = "fixed";
-  videoAreaOverlay.style.top = "0";
-  videoAreaOverlay.style.left = "0";
-  videoAreaOverlay.style.width = "100%";
-  videoAreaOverlay.style.height = "calc(100% - 140px)"; // Exclude Netflix controls area
-  videoAreaOverlay.style.zIndex = "9997";
-  videoAreaOverlay.style.cursor = "pointer";
-  videoAreaOverlay.style.backgroundColor = "transparent";
 
   state.controllerElement = document.createElement("div");
   state.controllerElement.id = CONTROLLER_ID;

--- a/Firefox/netflix-controller.css
+++ b/Firefox/netflix-controller.css
@@ -23,7 +23,7 @@
     color: white;
     padding: 18px 20px;
     padding-top: 60px; /* Extended padding for better gradient effect */
-    z-index: 99;
+    z-index: 9998;
     display: flex;
     align-items: center; /* Changed from flex-end to center for better alignment */
     justify-content: space-between;
@@ -53,9 +53,9 @@
     top: 0;
     left: 0;
     width: 100%;
-    height: calc(100% - 140px); /* Exclude Netflix controls area */
+    height: 100%;
     z-index: 99;
-    cursor: pointer;
+    cursor: default;
     background-color: transparent;
 }
 
@@ -761,4 +761,23 @@ body.nikflix-active .watch-video--bottom-controls-container,
 body.nikflix-active .watch-video--back-container,
 body.nikflix-active .watch-video--flag-container {
   display: none !important;
+}
+
+/* let clicks on the controller's own background reach the video underneath */
+#mon-controleur-netflix {
+    pointer-events: none;
+}
+
+#mon-controleur-netflix button,
+#mon-controleur-netflix input,
+#mon-controleur-netflix #netflix-volume-icon,
+#mon-controleur-netflix #netflix-barre-container {
+    pointer-events: auto;
+}
+
+#mon-controleur-netflix.hidden button,
+#mon-controleur-netflix.hidden input,
+#mon-controleur-netflix.hidden #netflix-volume-icon,
+#mon-controleur-netflix.hidden #netflix-barre-container {
+    pointer-events: none;
 }

--- a/Firefox/netflix-controller.css
+++ b/Firefox/netflix-controller.css
@@ -705,7 +705,7 @@ input:checked + .subtitle-toggle-slider:before {
     width: 40px;
     height: 40px;
     border-radius: 50%;
-    margin-right: 23px;
+    margin-right: 15px;
     cursor: pointer;
     display: flex;
     align-items: center;

--- a/Firefox/netflix-controller.css
+++ b/Firefox/netflix-controller.css
@@ -125,6 +125,7 @@
 
 #netflix-play-pause:hover,
 #netflix-plein-ecran:hover,
+#netflix-next-episode:hover,
 #netflix-subtitle-toggle:hover,
 #netflix-remove-toggle:hover {
     background-color: rgba(255, 255, 255, 0.1);
@@ -133,6 +134,7 @@
 
 #netflix-play-pause:active,
 #netflix-plein-ecran:active,
+#netflix-next-episode:active,
 #netflix-subtitle-toggle:active,
 #netflix-remove-toggle:active {
     transform: scale(0.95);

--- a/Firefox/netflix-controller.css
+++ b/Firefox/netflix-controller.css
@@ -10,6 +10,7 @@
     bottom: 0;
     left: 0;
     width: 100%;
+    box-sizing: border-box;
     background: linear-gradient(to top,
     rgba(0, 0, 0, 1) 0%,
     rgba(0, 0, 0, 0.9) 10%,
@@ -782,4 +783,8 @@ body.nikflix-active .watch-video--flag-container {
 #mon-controleur-netflix.hidden #netflix-volume-icon,
 #mon-controleur-netflix.hidden #netflix-barre-container {
     pointer-events: none;
+}
+
+#mon-controleur-netflix .controls-right > *:last-child {
+    margin-right: 0;
 }

--- a/Firefox/netflix-controller.css
+++ b/Firefox/netflix-controller.css
@@ -788,3 +788,22 @@ body.nikflix-active .watch-video--flag-container {
 #mon-controleur-netflix .controls-right > *:last-child {
     margin-right: 0;
 }
+
+/* beats the inline cursor the show-controls handler writes on mousemove */
+#netflix-video-area-overlay.over-netflix-button {
+    cursor: pointer !important;
+}
+
+/* lift netflix's skip buttons clear of our controller, like their own bar does */
+body.nikflix-controls-visible .watch-video--skip-content,
+body.nikflix-controls-visible .watch-video--skip-preplay,
+body.nikflix-controls-visible .SeamlessControls--container {
+    transform: translateY(calc(var(--nikflix-controls-height, 118px) * -1));
+}
+
+/* netflix keeps these up after a seek back to the middle, so hide them whenever
+   the playhead is nowhere near the end */
+body.nikflix-away-from-end .SeamlessControls--container {
+    opacity: 0 !important;
+    visibility: hidden !important;
+}

--- a/chromium/Main.js
+++ b/chromium/Main.js
@@ -1315,9 +1315,6 @@ function addMediaController() {
     }
   });
 
-  // Append to right controls bar
-  controlsRight.appendChild(speedToggleButton);
-
   // === Autoplay Next Episode Toggle ===
   const autoplayToggleButton = document.createElement("button");
   autoplayToggleButton.id = "netflix-autoplay-toggle";
@@ -1489,8 +1486,8 @@ function addMediaController() {
   controlsRight.appendChild(episodesButton);
   controlsRight.appendChild(removeToggle);
   controlsRight.appendChild(subtitleToggle);
-  controlsRight.appendChild(state.buttonFullScreen);
   controlsRight.appendChild(speedToggleButton);
+  controlsRight.appendChild(state.buttonFullScreen);
 
   state.controllerElement.appendChild(controlsLeft);
   state.controllerElement.appendChild(progressContainer);

--- a/chromium/Main.js
+++ b/chromium/Main.js
@@ -455,6 +455,19 @@ function showController() {
   }
   state.isControllerVisible = true;
 
+  // netflix lifts its skip buttons by reflow, ours is fixed so it can't
+  document.body.classList.add("nikflix-controls-visible");
+  if (state.controllerElement) {
+    // the top padding is just transparent gradient, only clear the controls
+    const rect = state.controllerElement.getBoundingClientRect();
+    const padTop =
+      parseFloat(getComputedStyle(state.controllerElement).paddingTop) || 0;
+    document.body.style.setProperty(
+      "--nikflix-controls-height",
+      `${Math.round(rect.height - padTop)}px`
+    );
+  }
+
   // Show cursor when controls are visible
   const videoAreaOverlay = document.getElementById(
     "netflix-video-area-overlay"
@@ -483,10 +496,12 @@ function showController() {
       }
 
       state.isControllerVisible = false;
+      document.body.classList.remove("nikflix-controls-visible");
 
       // Hide cursor when controls are hidden
       if (videoAreaOverlay) {
         videoAreaOverlay.style.cursor = "none";
+        videoAreaOverlay.classList.remove("over-netflix-button");
       }
     }
   }, CONTROLLER_HIDE_DELAY);
@@ -880,6 +895,66 @@ function createVideoOverlay() {
   document.body.appendChild(state.videoOverlay);
 }
 
+const NETFLIX_PASSTHROUGH_BUTTONS =
+  '[data-uia^="player-skip"], [data-uia$="seamless-button"], [data-uia$="seamless-button-draining"]';
+
+// netflix never dismisses its next episode controls on a seek, so key them off
+// how far the playhead is from the end instead
+const SEAMLESS_END_WINDOW_S = 120;
+
+function updateSeamlessDistance() {
+  const video = state.videoElement;
+  if (!video || !video.duration || Number.isNaN(video.duration)) return;
+
+  const remaining = video.duration - video.currentTime;
+  document.body.classList.toggle(
+    "nikflix-away-from-end",
+    remaining > SEAMLESS_END_WINDOW_S
+  );
+}
+
+function cancelNetflixCountdown() {
+  const container = document.querySelector(".SeamlessControls--container");
+  if (!container) return;
+
+  // netflix only cancels its next episode countdown once the mouse has
+  // travelled ~50px over this container, and our overlay swallows the real
+  // events, so replay enough of them to clear its timers
+  for (let i = 0; i < 8; i++) {
+    container.dispatchEvent(
+      new MouseEvent("mousemove", {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        clientX: 200 + i * 20,
+        clientY: 300,
+      })
+    );
+  }
+}
+
+function forwardHover(from, to) {
+  const fire = (el, types, related) => {
+    for (const type of types) {
+      const Ctor = type.startsWith("pointer") ? PointerEvent : MouseEvent;
+      el.dispatchEvent(
+        new Ctor(type, {
+          bubbles: type.endsWith("over") || type.endsWith("out"),
+          cancelable: true,
+          composed: true,
+          relatedTarget: related || null,
+          ...(Ctor === PointerEvent
+            ? { pointerId: 1, pointerType: "mouse", isPrimary: true }
+            : {}),
+        })
+      );
+    }
+  };
+
+  if (from) fire(from, ["pointerout", "mouseout", "pointerleave", "mouseleave"], to);
+  if (to) fire(to, ["pointerover", "mouseover", "pointerenter", "mouseenter"], from);
+}
+
 function createVideoAreaOverlay() {
   const curEpisodeId = getIdFromUrl();
   if (!curEpisodeId) return null; // If we can't get the episode ID, we won't create the overlay
@@ -923,6 +998,13 @@ function createVideoAreaOverlay() {
       return;
     }
 
+    const passthroughButton =
+      elementBelow && elementBelow.closest(NETFLIX_PASSTHROUGH_BUTTONS);
+    if (passthroughButton) {
+      passthroughButton.click();
+      return;
+    }
+
     if (state.videoElement.paused) {
       state.videoElement.play();
       if (state.buttonPlayPause) {
@@ -935,6 +1017,45 @@ function createVideoAreaOverlay() {
         state.buttonPlayPause.innerHTML =
           '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8 5V19L19 12L8 5Z" fill="white"/></svg>';
       }
+    }
+  });
+
+  // netflix's skip buttons sit under our overlay, so show a pointer over them
+  let lastCursorCheck = 0;
+  let lastHovered = null;
+  videoAreaOverlay.addEventListener("mousemove", (e) => {
+    // the hit test forces a style recalc, so keep it off every mousemove
+    if (e.timeStamp - lastCursorCheck < 100) return;
+    lastCursorCheck = e.timeStamp;
+
+    videoAreaOverlay.style.pointerEvents = "none";
+    const below = document.elementFromPoint(e.clientX, e.clientY);
+    videoAreaOverlay.style.pointerEvents = "auto";
+    const hovered = below && below.closest(NETFLIX_PASSTHROUGH_BUTTONS);
+
+    // a class, not an inline style: the show-controls handler also writes
+    // cursor on mousemove and would overwrite us
+    videoAreaOverlay.classList.toggle("over-netflix-button", !!hovered);
+
+    // only while actually over a button: the seamless container is full-bleed,
+    // and feeding it activity everywhere kept netflix's controls awake forever
+    if (hovered) {
+      below.dispatchEvent(
+        new MouseEvent("mousemove", {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          clientX: e.clientX,
+          clientY: e.clientY,
+        })
+      );
+    }
+
+    if (hovered !== lastHovered) {
+      // netflix pauses its autoplay countdown on hover, but the overlay
+      // swallows the real events so they have to be replayed
+      forwardHover(lastHovered, hovered);
+      lastHovered = hovered;
     }
   });
 
@@ -1368,6 +1489,10 @@ function addMediaController() {
       state.isControllerVisible = true;
     }
   });
+
+  // seeking away means the user is not waiting for the next episode
+  state.videoElement.addEventListener("seeked", cancelNetflixCountdown);
+  state.videoElement.addEventListener("timeupdate", updateSeamlessDistance);
 
   // Listen for video end event for autoplay next episode
   state.videoElement.addEventListener("ended", () => {

--- a/chromium/Main.js
+++ b/chromium/Main.js
@@ -460,7 +460,7 @@ function showController() {
     "netflix-video-area-overlay"
   );
   if (videoAreaOverlay) {
-    videoAreaOverlay.style.cursor = "pointer";
+    videoAreaOverlay.style.cursor = "default";
   }
 
   if (state.controllerHideTimer) {
@@ -890,9 +890,9 @@ function createVideoAreaOverlay() {
   videoAreaOverlay.style.top = "0";
   videoAreaOverlay.style.left = "0";
   videoAreaOverlay.style.width = "100%";
-  videoAreaOverlay.style.height = "calc(100% - 140px)";
+  videoAreaOverlay.style.height = "100%";
   videoAreaOverlay.style.zIndex = "9997";
-  videoAreaOverlay.style.cursor = "pointer";
+  videoAreaOverlay.style.cursor = "default";
   videoAreaOverlay.style.backgroundColor = "transparent";
 
   // Make it focusable
@@ -1087,17 +1087,6 @@ function addMediaController() {
   state.videoOverlay = document.createElement("div");
   state.videoOverlay.id = "netflix-video-overlay";
   state.videoOverlay.style.pointerEvents = "none"; // Allow clicks to pass through to Netflix's controls
-
-  // Create a separate overlay just for the video area (excluding controls)
-  videoAreaOverlay.id = "netflix-video-area-overlay";
-  videoAreaOverlay.style.position = "fixed";
-  videoAreaOverlay.style.top = "0";
-  videoAreaOverlay.style.left = "0";
-  videoAreaOverlay.style.width = "100%";
-  videoAreaOverlay.style.height = "calc(100% - 140px)"; // Exclude Netflix controls area
-  videoAreaOverlay.style.zIndex = "9997";
-  videoAreaOverlay.style.cursor = "pointer";
-  videoAreaOverlay.style.backgroundColor = "transparent";
 
   state.controllerElement = document.createElement("div");
   state.controllerElement.id = CONTROLLER_ID;

--- a/chromium/netflix-controller.css
+++ b/chromium/netflix-controller.css
@@ -708,7 +708,7 @@ input:checked + .subtitle-toggle-slider:before {
     width: 40px;
     height: 40px;
     border-radius: 50%;
-    margin-right: 23px;
+    margin-right: 15px;
     cursor: pointer;
     display: flex;
     align-items: center;

--- a/chromium/netflix-controller.css
+++ b/chromium/netflix-controller.css
@@ -126,6 +126,7 @@
 
 #netflix-play-pause:hover,
 #netflix-plein-ecran:hover,
+#netflix-next-episode:hover,
 #netflix-autoplay-toggle:hover,
 #netflix-subtitle-toggle:hover,
 #netflix-remove-toggle:hover {
@@ -135,6 +136,7 @@
 
 #netflix-play-pause:active,
 #netflix-plein-ecran:active,
+#netflix-next-episode:active,
 #netflix-autoplay-toggle:active,
 #netflix-subtitle-toggle:active,
 #netflix-remove-toggle:active {

--- a/chromium/netflix-controller.css
+++ b/chromium/netflix-controller.css
@@ -10,6 +10,7 @@
     bottom: 0;
     left: 0;
     width: 100%;
+    box-sizing: border-box;
     background: linear-gradient(to top,
     rgba(0, 0, 0, 1) 0%,
     rgba(0, 0, 0, 0.9) 10%,
@@ -786,4 +787,8 @@ body.nikflix-active .watch-video--flag-container {
 #mon-controleur-netflix.hidden #netflix-volume-icon,
 #mon-controleur-netflix.hidden #netflix-barre-container {
     pointer-events: none;
+}
+
+#mon-controleur-netflix .controls-right > *:last-child {
+    margin-right: 0;
 }

--- a/chromium/netflix-controller.css
+++ b/chromium/netflix-controller.css
@@ -792,3 +792,22 @@ body.nikflix-active .watch-video--flag-container {
 #mon-controleur-netflix .controls-right > *:last-child {
     margin-right: 0;
 }
+
+/* beats the inline cursor the show-controls handler writes on mousemove */
+#netflix-video-area-overlay.over-netflix-button {
+    cursor: pointer !important;
+}
+
+/* lift netflix's skip buttons clear of our controller, like their own bar does */
+body.nikflix-controls-visible .watch-video--skip-content,
+body.nikflix-controls-visible .watch-video--skip-preplay,
+body.nikflix-controls-visible .SeamlessControls--container {
+    transform: translateY(calc(var(--nikflix-controls-height, 118px) * -1));
+}
+
+/* netflix keeps these up after a seek back to the middle, so hide them whenever
+   the playhead is nowhere near the end */
+body.nikflix-away-from-end .SeamlessControls--container {
+    opacity: 0 !important;
+    visibility: hidden !important;
+}

--- a/chromium/netflix-controller.css
+++ b/chromium/netflix-controller.css
@@ -23,7 +23,7 @@
     color: white;
     padding: 18px 20px;
     padding-top: 60px; /* Extended padding for better gradient effect */
-    z-index: 1000;
+    z-index: 9998;
     display: flex;
     align-items: center; /* Changed from flex-end to center for better alignment */
     justify-content: space-between;
@@ -53,9 +53,9 @@
     top: 0;
     left: 0;
     width: 100%;
-    height: calc(100% - 140px); /* Exclude Netflix controls area */
+    height: 100%;
     z-index: 99;
-    cursor: pointer;
+    cursor: default;
     background-color: transparent;
 }
 
@@ -765,4 +765,23 @@ body.nikflix-active .watch-video--bottom-controls-container,
 body.nikflix-active .watch-video--back-container,
 body.nikflix-active .watch-video--flag-container {
   display: none !important;
+}
+
+/* let clicks on the controller's own background reach the video underneath */
+#mon-controleur-netflix {
+    pointer-events: none;
+}
+
+#mon-controleur-netflix button,
+#mon-controleur-netflix input,
+#mon-controleur-netflix #netflix-volume-icon,
+#mon-controleur-netflix #netflix-barre-container {
+    pointer-events: auto;
+}
+
+#mon-controleur-netflix.hidden button,
+#mon-controleur-netflix.hidden input,
+#mon-controleur-netflix.hidden #netflix-volume-icon,
+#mon-controleur-netflix.hidden #netflix-barre-container {
+    pointer-events: none;
 }


### PR DESCRIPTION
clicks near the bottom of the player did nothing because the overlay stopped 140px short, it now covers the whole player with `pointer-events` off on the controller background so the gradient passes clicks through

also, cursor is `default` over the video instead of `pointer`, the next episode button got the hover animation every other icon has, and the speed button moved to the left of fullscreen

the overlay also covered netflix's skip intro and next episode buttons, so clicks and hover are forwarded to them, they are lifted clear of our controller, and since netflix only cancels its countdown on mouse travel it is cancelled on seek too, otherwise it kept running and jumped to the next episode