### PR TITLE
fix: controller not rebuilding when netflix changes episode

### DIFF
--- a/Firefox/Main.js
+++ b/Firefox/Main.js
@@ -29,6 +29,7 @@ let state = {
   screenTime: null,
   videoElement: null,
   currentEpisodeDuration: null,
+  currentEpisodeId: null,
   volumeSlider: null,
   lastScreenTime: -1,
   lastTotalTime: -1,
@@ -1621,6 +1622,17 @@ const observerOptions = {
 
 const observer = new MutationObserver((mutations) => {
   if (state.mutationTimeout) clearTimeout(state.mutationTimeout);
+
+  // netflix swaps episodes without reloading, so tear down and let the
+  // controller rebuild instead of keeping a stale video element
+  const episodeId = getIdFromUrl();
+  if (episodeId !== state.currentEpisodeId) {
+    if (state.currentEpisodeId !== null) {
+      cleanController();
+      state.currentEpisodeDuration = null;
+    }
+    state.currentEpisodeId = episodeId;
+  }
 
   // Handle restriction screen: remove it, resume video and show controller
   const hasRestrictionNode = mutations.some((mutation) =>

--- a/chromium/Main.js
+++ b/chromium/Main.js
@@ -30,6 +30,7 @@ let state = {
   screenTime: null,
   videoElement: null,
   currentEpisodeDuration: null,
+  currentEpisodeId: null,
   volumeSlider: null,
   lastScreenTime: -1,
   lastTotalTime: -1,
@@ -1622,6 +1623,17 @@ const observerOptions = {
 
 const observer = new MutationObserver((mutations) => {
   if (state.mutationTimeout) clearTimeout(state.mutationTimeout);
+
+  // netflix swaps episodes without reloading, so tear down and let the
+  // controller rebuild instead of keeping a stale video element
+  const episodeId = getIdFromUrl();
+  if (episodeId !== state.currentEpisodeId) {
+    if (state.currentEpisodeId !== null) {
+      cleanController();
+      state.currentEpisodeDuration = null;
+    }
+    state.currentEpisodeId = episodeId;
+  }
 
   // Handle restriction screen: remove it, resume video and show controller
   const hasRestrictionNode = mutations.some((mutation) =>


### PR DESCRIPTION
netflix swaps episodes without reloading the page, and `addMediaController()` returns early when `isControllerAdded` is set, so nothing rebuilt and `state.videoElement` kept pointing at the previous element, time stuck and the buttons dead

the observer now compares the episode id from the url and tears down when it changes, so the controller rebuilds against the live video, and the cached episode duration is cleared with it